### PR TITLE
Add `lineHeight` too

### DIFF
--- a/src/top-bar/TopBar.js
+++ b/src/top-bar/TopBar.js
@@ -52,6 +52,7 @@ const styles = StyleSheet.create({
   menuOptionText: {
     flex: 1,
     fontSize: 15,
+    lineHeight: 20,
     color: '#212121',
     marginLeft: 7,
   },


### PR DESCRIPTION
Add `lineHeight` to `menuOptionText` so there's not too much spacing between lines in wrapped text